### PR TITLE
Added Insert Mode Lock

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,30 @@
+[
+  {
+    "caption": "Preferences",
+    "mnemonic": "n",
+    "id": "preferences",
+    "children":
+    [
+      {
+        "caption": "Package Settings",
+        "mnemonic": "P",
+        "id": "package-settings",
+        "children":
+        [
+          {
+            "caption": "Actual Vim",
+            "children":
+            [
+              {
+                "command": "toggle_insert_lock",
+                "args": { "setting": "insert_lock"},
+                "caption": "Insert Mode Lock",
+				"checkbox":true
+              },
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/actual.py
+++ b/actual.py
@@ -111,9 +111,31 @@ class ActualVim(ViewMeta):
 class ActualKeypress(sublime_plugin.TextCommand):
     def run(self, edit, key):
         v = ActualVim.get(self.view, exact=False)
-        if v and v.actual:
-            v.vim.press(key)
+        exit_insert_mode_keys = ["escape", "ctrl+C", "ctrl+["]
+        if key in exit_insert_mode_keys:
+            settings = sublime.load_settings("actual.sublime-settings")
+            if v.vim.mode == "i" and settings.get("insert_lock", False):
+			    #Do not send esc, ctrl-c, ctrl-[
+                pass
+            else:
+                if v and v.actual:
+                    v.vim.press(key)
+        else: 
+            if v and v.actual:
+                v.vim.press(key)
 
+class ToggleInsertLock(sublime_plugin.ApplicationCommand):
+	settings = sublime.load_settings("actual.sublime-settings")
+
+	def run(self, setting):
+		self.settings.set(setting, not self.settings.get(setting))
+		sublime.save_settings("actual.sublime-settings")
+		
+	def is_checked(self, setting):
+		if self.settings.get(setting):
+			return True
+		else:
+			return False
 
 class ActualListener(sublime_plugin.EventListener):
     def on_new_async(self, view):

--- a/actual.sublime-settings
+++ b/actual.sublime-settings
@@ -1,0 +1,3 @@
+{
+	"insert_lock":false
+}


### PR DESCRIPTION
In short, I added a setting to 'lock' insert mode, so that once insert mode is entered, it cannot be exited if the lock is turned on (basically, it listens for any keys/key-combos that would exit insert mode and just doesn't pass them to vim)

What it doesn't do (yet) is automatically switch you to insert mode when you turn on the lock. Currently it's toggled via Preferences -> Package Settings -> Actual Vim -> Insert Lock.

What I know/think it still needs: 
- To force you into insert mode when you turn it on. (Using a settings.add_on_change() to send an "i" keypress would make this simple enough; I just didn't get a chance to put that together yet)
- To have a keyboard shortcut.
