### PR TITLE
fixed problem of move right when has unicode character

### DIFF
--- a/neo.py
+++ b/neo.py
@@ -306,7 +306,11 @@ class Vim:
         mode_last = self.status_last.get('mode')
         was_ready = self.ready.acquire(False)
 
-        ret = self.nv.input(key)
+        try:
+            ret = self.nv.input(key)
+        except Exception:
+            return 0, False
+
         if self.nvim_mode:
             res = self.nv.request('nvim_get_mode') or {}
             ready = not res.get('blocking', True)

--- a/view.py
+++ b/view.py
@@ -173,7 +173,6 @@ class ActualVim:
 
         vcol = len(line)
         return view.text_point(row, vcol)
-        return view.text_point(row, vcol)
 
     def vim_rowcol(self, point):
         view = self.view

--- a/view.py
+++ b/view.py
@@ -163,7 +163,16 @@ class ActualVim:
         view = self.view
         pos = view.text_point(row, 0)
         line = view.substr(sublime.Region(pos, pos + col))
-        vcol = len(line.encode('utf-8')[:col].decode('utf-8'))
+        encoded_line=line.encode('utf-8')
+        while(True):           #col is byte number of line-head to cursor, so line is long then we need
+            try:
+                line=encoded_line[:col].decode('utf-8') #get only line-head to cursor character
+                break
+            except:
+                col=col+1      #when use unicode character, it may half display in top-left
+
+        vcol = len(line)
+        return view.text_point(row, vcol)
         return view.text_point(row, vcol)
 
     def vim_rowcol(self, point):

--- a/view.py
+++ b/view.py
@@ -583,7 +583,11 @@ class ActualVim:
 
             # syncing the viewport to vim here fixes the case where the user scrolled the view in sublime between keypresses
             if neo.vim.nvim_mode:
-                res = neo.vim.nv.request('nvim_get_mode') or {}
+                try:
+                    res = neo.vim.nv.request('nvim_get_mode') or {}
+                except Exception:
+                    res = {};
+
                 if not res.get('blocking', True):
                     self.viewport_to_vim()
 
@@ -689,7 +693,11 @@ class ActualVim:
                         self.update_needed += 1
                     def onready():
                         sublime.set_timeout(self.update, 0)
-                    _, ready = neo.vim.press('<cr>', onready)
+                        
+                    try:
+                        _, ready = neo.vim.press('<cr>', onready)
+                    except Exception:
+                        ready = True
                     if ready: self.update()
 
                 def on_cancel():


### PR DESCRIPTION
fixed the unicode problem which will cause decode error when half of unicode character display on top-left in back-end vim